### PR TITLE
add marshmallow expiriment for schema, pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,9 @@ python:
   - "3.5"
 install:
   - pip install -r requirements.txt
+before_script:
+  - cp settings.json.example settings.json
 script: nosetests -sv
+branches:
+  only:
+    - master

--- a/jobs/fatal_od.py
+++ b/jobs/fatal_od.py
@@ -1,0 +1,42 @@
+import datetime
+from marshmallow import fields, post_load
+
+import pipeline as pl
+
+class FatalODSchema(pl.BaseSchema):
+    death_date = fields.DateTime(format='%m/%d/%Y')
+    death_time = fields.DateTime(format='%I:%M %p')
+    manner_of_death = fields.String()
+    age = fields.Integer()
+    sex = fields.String()
+    race = fields.String()
+    case_dispo = fields.String()
+    combined_od1 = fields.String()
+    combined_od2 = fields.String()
+    combined_od3 = fields.String()
+    combined_od4 = fields.String()
+    combined_od5 = fields.String()
+    combined_od6 = fields.String()
+    combined_od7 = fields.String()
+    incident_zip = fields.Integer()
+    decedent_zip = fields.Integer()
+    case_year = fields.Integer()
+
+    @post_load
+    def combine_date_and_time(self, in_data):
+        death_date, death_time = in_data['death_date'], in_data['death_time']
+        in_data['death_date_and_time'] = datetime.datetime(
+            death_date.year, death_date.month, death_date.day,
+            death_time.hour, death_time.minute, death_time.second
+        )
+
+    @post_load
+    def replace_death_time_date(self, in_data):
+        today = datetime.datetime.today()
+        in_data['death_time'].replace(
+            year=today.year, month=today.month, day=today.day
+        )
+
+fatal_od_pipeline = pl.Pipeline().extract(pl.CSVExtractor, firstline=True) \
+    .schema(FatalODSchema) \
+    .load(pl.Datapusher)

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,0 +1,4 @@
+from .extractors import FileExtractor, CSVExtractor, SFTPExtractor
+from .loaders import Datapusher
+from .pipelines import Pipeline
+from .schema import BaseSchema

--- a/pipeline/extractors.py
+++ b/pipeline/extractors.py
@@ -1,0 +1,73 @@
+class Extractor(object):
+    def __init__(self, target, *args, **kwargs):
+        self.target = target
+
+    def extract(self):
+        '''Return a generator. Must be implemented in subclasses
+        '''
+        raise NotImplementedError
+
+    def handle_line(self, line):
+        '''Handle each line or row in a particular file.
+        '''
+        raise NotImplementedError
+
+    def cleanup(self, *args, **kwargs):
+        '''Perform whatever cleanup is necessary to the extractor.
+        '''
+        raise NotImplementedError
+
+    def get_headers(self):
+        '''Gets the column names or headers. Required for serialization
+        '''
+        raise NotImplementedError
+
+class FileExtractor(Extractor):
+    def __init__(self, target):
+        self.target = target
+
+    def extract(self):
+        try:
+            f = open(self.target)
+            return f
+        except IOError as e:
+            raise e
+
+    def cleanup(self, f):
+        '''Closes a file object if it isn't closed already
+        '''
+        f.close()
+        return
+
+class CSVExtractor(FileExtractor):
+    def __init__(self, target, *args, **kwargs):
+        super(CSVExtractor, self).__init__(target)
+        self.firstline = kwargs.get('firstline', True)
+        self.headers = kwargs.get('headers', None)
+
+        self.set_headers()
+
+    def handle_line(self, line):
+        parsed = line.strip('\n').strip('\r\n').split(',')
+        if parsed == self.headers:
+            return None
+        return dict(zip(self.schema_headers, parsed))
+
+    def set_headers(self):
+        if self.firstline:
+            with open(self.target) as f:
+                self.headers = f.readline().strip('\n').strip('\r\n').split(',')
+                self.schema_headers = [
+                    i.lower().replace(' ', '_') for i in
+                    self.headers
+                ]
+                return
+        else:
+            if self.headers:
+                self.schema_headers = self.headers
+                return
+
+        raise RuntimeError('No headers were passed or detected.')
+
+class SFTPExtractor(Extractor):
+    pass

--- a/pipeline/loaders.py
+++ b/pipeline/loaders.py
@@ -16,6 +16,7 @@ class Loader(object):
 class Datapusher(Loader):
     """Connection to ckan datastore"""
     def __init__(self, server="staging", settings_file=None):
+        f = None
         settings_file = settings_file if settings_file else \
             os.path.join(PARENT, 'settings.json')
         try:
@@ -27,7 +28,8 @@ class Datapusher(Loader):
                 'No config file found, or config not properly formatted'
             )
         finally:
-            f.close()
+            if f:
+                f.close()
 
         self.ckan_url = self.config['root_url'].rstrip('/') + '/api/3/'
         self.dump_url = self.config['root_url'].rstrip('/') + '/datastore/dump/'

--- a/pipeline/loaders.py
+++ b/pipeline/loaders.py
@@ -1,23 +1,33 @@
+import os
 import requests
 import json
 import datetime
 
+HERE = os.path.abspath(os.path.dirname(__file__))
+PARENT = os.path.join(HERE, '..')
 
 class InvalidConfigException(Exception):
     pass
 
+class Loader(object):
+    def load(self, data):
+        raise NotImplementedError
 
-class Datapusher(object):
+class Datapusher(Loader):
     """Connection to ckan datastore"""
-
-    def __init__(self, server="staging", settings_file='../settings.json'):
+    def __init__(self, server="staging", settings_file=None):
+        settings_file = settings_file if settings_file else \
+            os.path.join(PARENT, 'settings.json')
         try:
-            raw_config = json.load(open(settings_file))
+            f = open(settings_file, 'r')
+            raw_config = json.loads(f.read())
             self.config = raw_config[server]
         except (KeyError, IOError):
             raise InvalidConfigException(
-                    'No config file found, or config not properly formatted'
+                'No config file found, or config not properly formatted'
             )
+        finally:
+            f.close()
 
         self.ckan_url = self.config['root_url'].rstrip('/') + '/api/3/'
         self.dump_url = self.config['root_url'].rstrip('/') + '/datastore/dump/'
@@ -37,14 +47,14 @@ class Datapusher(object):
         """
 
         check_resource = requests.post(
-                self.ckan_url + 'action/package_show',
-                headers={
-                    'content-type': 'application/json',
-                    'authorization': self.key
-                },
-                data=json.dumps({
-                    'id': package_id
-                })
+            self.ckan_url + 'action/package_show',
+            headers={
+                'content-type': 'application/json',
+                'authorization': self.key
+            },
+            data=json.dumps({
+                'id': package_id
+            })
         )
 
         response = check_resource.json()
@@ -64,18 +74,18 @@ class Datapusher(object):
 
         # Make api call
         create_resource = requests.post(
-                self.ckan_url + 'action/resource_create',
-                headers={
-                    'content-type': 'application/json',
-                    'authorization': self.key
-                },
-                data=json.dumps({
-                    'package_id': package_id,
-                    'url': '#',
-                    'name': resource_name,
-                    'url_type': 'datapusher',
-                    'format': 'CSV'
-                })
+            self.ckan_url + 'action/resource_create',
+            headers={
+                'content-type': 'application/json',
+                'authorization': self.key
+            },
+            data=json.dumps({
+                'package_id': package_id,
+                'url': '#',
+                'name': resource_name,
+                'url_type': 'datapusher',
+                'format': 'CSV'
+            })
         )
 
         resource = create_resource.json()
@@ -101,16 +111,16 @@ class Datapusher(object):
 
         # Make API call
         create_datastore = requests.post(
-                self.ckan_url + 'action/datastore_create',
-                headers={
-                    'content-type': 'application/json',
-                    'authorization': self.key
-                },
-                data=json.dumps({
-                    'resource_id': resource_id,
-                    'force': True,
-                    'fields': fields
-                })
+            self.ckan_url + 'action/datastore_create',
+            headers={
+                'content-type': 'application/json',
+                'authorization': self.key
+            },
+            data=json.dumps({
+                'resource_id': resource_id,
+                'force': True,
+                'fields': fields
+            })
         )
 
         create_datastore = create_datastore.json()
@@ -120,9 +130,9 @@ class Datapusher(object):
             return
 
         print(
-                'SUCCESS: Datastore #{} was created.'.format(
-                        create_datastore['result']['resource_id']
-                )
+            'SUCCESS: Datastore #{} was created.'.format(
+                create_datastore['result']['resource_id']
+            )
         )
 
         return create_datastore['result']['resource_id']
@@ -138,15 +148,15 @@ class Datapusher(object):
             Status code from the request
         """
         delete = requests.post(
-                self.ckan_url + 'action/datastore_delete',
-                headers={
-                    'content-type': 'application/json',
-                    'authorization': self.key
-                },
-                data=json.dumps({
-                    'resource_id': resource_id,
-                    'force': True
-                })
+            self.ckan_url + 'action/datastore_delete',
+            headers={
+                'content-type': 'application/json',
+                'authorization': self.key
+            },
+            data=json.dumps({
+                'resource_id': resource_id,
+                'force': True
+            })
         )
         return delete.status_code
 
@@ -162,17 +172,17 @@ class Datapusher(object):
             request status
         """
         insert = requests.post(
-                self.ckan_url + 'action/datastore_upsert',
-                headers={
-                    'content-type': 'application/json',
-                    'authorization': self.key
-                },
-                data=json.dumps({
-                    'resource_id': resource_id,
-                    'method': 'insert',
-                    'force': True,
-                    'records': data
-                })
+            self.ckan_url + 'action/datastore_upsert',
+            headers={
+                'content-type': 'application/json',
+                'authorization': self.key
+            },
+            data=json.dumps({
+                'resource_id': resource_id,
+                'method': 'insert',
+                'force': True,
+                'records': data
+            })
         )
         return insert.status_code
 
@@ -187,31 +197,19 @@ class Datapusher(object):
             request status
         """
         update = requests.post(
-                self.ckan_url + 'action/resource_patch',
-                headers={
-                    'content-type': 'application/json',
-                    'authorization': self.key
-                },
-                data=json.dumps({
-                    'id': resource_id,
-                    'url': self.dump_url + str(resource_id),
-                    'url_type': 'datapusher',
-                    'last_modified': datetime.datetime.now().isoformat(),
-                })
+            self.ckan_url + 'action/resource_patch',
+            headers={
+                'content-type': 'application/json',
+                'authorization': self.key
+            },
+            data=json.dumps({
+                'id': resource_id,
+                'url': self.dump_url + str(resource_id),
+                'url_type': 'datapusher',
+                'last_modified': datetime.datetime.now().isoformat(),
+            })
         )
         return update.status_code
 
-    def get_metadata(self, resource_id):
-        """
-        Uses ckan.logic.action.get
-
-            Params:
-                resource_id resource whose metadata will be retrieved
-            Returns:
-                dict containing resource metadata
-        """
-        metadata = requests.get(
-                self.ckan_url + 'action/resource_show',
-                {'id': resource_id}
-        )
-        return metadata['data']
+    def load(self, data):
+        pass

--- a/pipeline/pipelines.py
+++ b/pipeline/pipelines.py
@@ -1,0 +1,59 @@
+class Pipeline(object):
+    def __init__(self):
+        self.data = []
+
+    def extract(self, extractor, *args, **kwargs):
+        self.extractor = extractor
+        self.extractor_args = list(*args)
+        self.extractor_kwargs = dict(**kwargs)
+        return self
+
+    def schema(self, schema):
+        self.schema = schema
+        return self
+
+    def load(self, loader):
+        self.loader = loader
+        return self
+
+    def load_line(self, data):
+        '''Load a line into the pipeline's data or throw an error
+        '''
+        loaded = self.schema().load(data)
+        if loaded.errors:
+            raise RuntimeError('There were errors in the input data: {}'.format(
+                loaded.errors.__str__()
+            ))
+        else:
+            self.data.append(loaded.data)
+
+    def _run(self):
+        # instantiate a new extrator instance based on the passed extract class
+        _extractor = self.extractor(
+            self.target, *(self.extractor_args), **(self.extractor_kwargs)
+        )
+        # instantiate a new schema instance based on the passed schema class
+        raw = self.extractor(self.target).extract()
+
+        # build the data
+        try:
+            for line in raw:
+                data = _extractor.handle_line(line)
+                if data:
+                    self.load_line(data)
+                else:
+                    continue
+        finally:
+            _extractor.cleanup(raw)
+
+        # load the data
+        self.loader().load(self.data)
+
+    def schedule(self, extract_target):
+        self.target = extract_target
+        return self
+
+    def run(self, extract_target):
+        self.target = extract_target
+        self._run()
+        return self

--- a/pipeline/schema.py
+++ b/pipeline/schema.py
@@ -1,0 +1,4 @@
+from marshmallow import Schema, fields
+
+class BaseSchema(Schema):
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests==2.9.1
 nose==1.3.7
-wextractor==0.1.dev3
--e git+https://github.com/nwcell/psycopg2-windows.git@win64-py27#egg=psycopg2
+marshmallow==2.4.2

--- a/test/pipelines/fatal_od_mock.csv
+++ b/test/pipelines/fatal_od_mock.csv
@@ -1,0 +1,2 @@
+Death Date,Death Time,Manner of Death,Age,Sex,Race,Case Dispo,Combined OD1,Combined OD2,Combined OD3,Combined OD4,Combined OD5,Combined OD6,Combined OD7,Incident Zip,Decedent Zip,Case Year
+01/01/2016,12:37 pm,Death,100,F,,,,,,,,,,00000,00000,2016

--- a/test/pipelines/test_fatal_od_pipeline.py
+++ b/test/pipelines/test_fatal_od_pipeline.py
@@ -1,0 +1,10 @@
+import os
+from jobs.fatal_od import fatal_od_pipeline
+
+from unittest import TestCase
+
+HERE = os.path.abspath(os.path.dirname(__file__))
+
+class TestODPipeline(TestCase):
+    def test_od_pipeline(self):
+        fatal_od_pipeline.run(os.path.join(HERE, 'fatal_od_mock.csv'))

--- a/test/unit/test_loader.py
+++ b/test/unit/test_loader.py
@@ -1,6 +1,5 @@
 import unittest
 import os
-import json
 
 from unittest.mock import Mock, patch, PropertyMock
 
@@ -22,8 +21,6 @@ class TestDatapusher(unittest.TestCase):
         self.assertEquals(self.data_pusher.dump_url, 'localhost:9000/datastore/dump/')
 
     def test_datapusher_exception_no_settings(self):
-        with self.assertRaises(InvalidConfigException):
-            Datapusher()
         with self.assertRaises(InvalidConfigException):
             Datapusher(
                 server='Does not exist',


### PR DESCRIPTION
This commit adds a depedency on Marshmallow[1], a lightweight serialization/deserialization library that can also handle validation, requiring fields, etc. Additionally, I have made an attempt to set up simple pipeline building through method chaining. For example, building a pipeline might look like this:

my_pipeline = Pipeline().extractor(CsvExractor).schema(MySchema).load(Datapusher)

This will instantiate a new Pipeline, which would then be able to be either scheduled or run as expected. That functionality is to be added later. I've added a sample job taken from the Fatal OD in the existing WPRDC codebase for an example of what this would look like (and a skeleton test for it as well).

[1] http://marshmallow.readthedocs.org/en/latest/

@saylorsd please take a look at this and let me know what you think.
