### PR TITLE
Upsert tests

### DIFF
--- a/jobs/fatal_od.py
+++ b/jobs/fatal_od.py
@@ -49,7 +49,7 @@ class FatalODSchema(pl.BaseSchema):
 package_id = '945f9505-f33b-46e1-9c43-6c3315b4b0cd'
 resource_name = 'Fatal Accidental OD 2014'
 
-fatal_od_pipeline = pl.Pipeline('fatal_od_pipeline', 'Fatal OD Pipeline') \
+fatal_od_pipeline = pl.Pipeline('fatal_od_pipeline', 'Fatal OD Pipeline', log_status=False) \
     .connect(pl.FileConnector, os.path.join(HERE, '../test/mock/fatal_od_mock.csv')) \
     .extract(pl.CSVExtractor, firstline_headers=True) \
     .schema(FatalODSchema) \
@@ -58,4 +58,3 @@ fatal_od_pipeline = pl.Pipeline('fatal_od_pipeline', 'Fatal OD Pipeline') \
           package_id=package_id,
           resource_name=resource_name,
           method='insert')
-

--- a/pipeline/loaders.py
+++ b/pipeline/loaders.py
@@ -163,7 +163,7 @@ class CKANLoader(Loader):
         Returns:
             request status
         """
-        insert = requests.post(
+        upsert = requests.post(
             self.ckan_url + 'action/datastore_upsert',
             headers={
                 'content-type': 'application/json',
@@ -176,7 +176,7 @@ class CKANLoader(Loader):
                 'records': data
             })
         )
-        return insert.status_code
+        return upsert.status_code
 
     def update_metadata(self, resource_id):
         """

--- a/test/unit/test_loader.py
+++ b/test/unit/test_loader.py
@@ -139,16 +139,36 @@ class TestCKANDatastoreLoader(TestCKANDatastoreBase):
             pl.CKANDatastoreLoader(self.pipeline.get_config())
 
     @patch('requests.post')
-    def test_datastore_load_successful(self, post):
+    def test_datastore_load__insert_successful(self, post):
         mock_post = Mock()
         mock_post.json.side_effect = [
-            {'success': True, 'result': {'id': 1}},
-            {'success': True, 'result': {'resource_id': 1}},
             {'success': True, 'result': {'id': 1}},
             {'success': True, 'result': {'resource_id': 1}},
         ]
         post.return_value = mock_post
         self.insert_loader.load([])
+
+    @patch('requests.post')
+    def test_datastore_load_insert_failed(self, post):
+        mock_post = Mock()
+        mock_post.json.side_effect = [
+            {'success': True, 'result': {'id': 1}},
+            {'success': True, 'result': {'resource_id': 1}},
+        ]
+        post.return_value = mock_post
+        type(post.return_value).status_code = PropertyMock(side_effect=[500, 200])
+
+        with self.assertRaises(RuntimeError):
+            self.insert_loader.load([])
+
+    @patch('requests.post')
+    def test_datastore_load__upsert_successful(self, post):
+        mock_post = Mock()
+        mock_post.json.side_effect = [
+            {'success': True, 'result': {'id': 1}},
+            {'success': True, 'result': {'resource_id': 1}},
+        ]
+        post.return_value = mock_post
         self.upsert_loader.load([])
 
     @patch('requests.post')
@@ -162,10 +182,10 @@ class TestCKANDatastoreLoader(TestCKANDatastoreBase):
         type(post.return_value).status_code = PropertyMock(side_effect=[500, 200])
 
         with self.assertRaises(RuntimeError):
-            self.insert_loader.load([])
+            self.upsert_loader.load([])
 
     @patch('requests.post')
-    def test_datastore_load_update_metadata_failed(self, post):
+    def test_datastore_load_insert_update_metadata_failed(self, post):
         mock_post = Mock()
         mock_post.json.side_effect = [
             {'success': True, 'result': {'id': 1}},
@@ -176,3 +196,14 @@ class TestCKANDatastoreLoader(TestCKANDatastoreBase):
         with self.assertRaises(RuntimeError):
             self.insert_loader.load([])
 
+    @patch('requests.post')
+    def test_datastore_load_upsert_update_metadata_failed(self, post):
+        mock_post = Mock()
+        mock_post.json.side_effect = [
+            {'success': True, 'result': {'id': 1}},
+            {'success': True, 'result': {'resource_id': 1}},
+        ]
+        post.return_value = mock_post
+        type(post.return_value).status_code = PropertyMock(side_effect=[200, 500])
+        with self.assertRaises(RuntimeError):
+            self.upsert_loader.load([])

--- a/test/unit/test_loader.py
+++ b/test/unit/test_loader.py
@@ -161,7 +161,7 @@ class TestCKANDatastoreLoader(TestCKANDatastoreBase):
         post.return_value = mock_post
 
         for error in self.error_codes:
-            type(post.return_value).status_code = PropertyMock(side_effect=[error, 200])
+            type(post.return_value).status_code = PropertyMock(return_value=error)
 
             with self.assertRaises(RuntimeError):
                 self.insert_loader.load([])
@@ -190,7 +190,7 @@ class TestCKANDatastoreLoader(TestCKANDatastoreBase):
         post.return_value = mock_post
 
         for error in self.error_codes:
-            type(post.return_value).status_code = PropertyMock(side_effect=[error, 200])
+            type(post.return_value).status_code = PropertyMock(return_value=error)
 
             with self.assertRaises(RuntimeError):
                 self.upsert_loader.load([])
@@ -219,6 +219,6 @@ class TestCKANDatastoreLoader(TestCKANDatastoreBase):
         post.return_value = mock_post
 
         for error in self.error_codes:
-            type(post.return_value).status_code = PropertyMock(side_effect=[200, 500])
+            type(post.return_value).status_code = PropertyMock(return_value=error)
             with self.assertRaises(RuntimeError):
                     self.upsert_loader.load([])


### PR DESCRIPTION
Added`method=upsert` tests for the `loaders` as well as tested against 409 error codes.

@bsmithgall Please take a look whenever you have a chance
Is iterating over the error codes a safe way to do it?
